### PR TITLE
[FIX] Service editing form button now says 'Edit Service'

### DIFF
--- a/Eventy/app/src/main/res/layout/fragment_service_editing.xml
+++ b/Eventy/app/src/main/res/layout/fragment_service_editing.xml
@@ -231,7 +231,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="60dp"
-            android:text="Create Service"
+            android:text="Edit Service"
             app:backgroundTint="@color/button_color"
             style="@style/Widget.MaterialComponents.Button"
             app:cornerRadius="7dp"


### PR DESCRIPTION
A very simple fix, just changed a button label. Hence, no reviewers will be appointed.